### PR TITLE
Add error handling for int indexing

### DIFF
--- a/lib/utils/nd_list.dart
+++ b/lib/utils/nd_list.dart
@@ -236,6 +236,11 @@ class NDList<X> {
   }
 
   NDList<X> _intIndex(int index) {
+    // error handling
+    if (index < -_shape[0] || index >= _shape[0]) {
+      throw RangeError(
+          'Index out of bounds: index $index is out of bounds for axis with size ${_shape[0]}');
+    }
     // return the appropriate axis-0 slice
     if (_shape.length == 1) {
       return NDList._([_list[index]], [1]);

--- a/test/utils_tests/nd_list_test.dart
+++ b/test/utils_tests/nd_list_test.dart
@@ -319,5 +319,20 @@ void main() {
 
       expect(cemented.shape, equals([3, 2, 2]));
     });
+
+    test('Test int indexing. Throw error only if out of bounds', () {
+      final data = [
+        [1.0, 2.0, 4.0],
+        [3.0, 4.0, 16.0]
+      ];
+      final ndList = NDList.from<double>(data);
+      // single int input
+      expect(ndList[0], equals(NDList.from<double>(data[0])));
+      expect(ndList[1], equals(NDList.from<double>(data[1])));
+      expect(() => ndList[2], throwsRangeError);
+      expect(ndList[-1], equals(NDList.from<double>(data[1])));
+      expect(ndList[-2], equals(NDList.from<double>(data[0])));
+      expect(() => ndList[-3], throwsRangeError);
+    });
   });
 }


### PR DESCRIPTION
Just dipping my toes here to try things out. I added that error message to give a bit more info when you are out of bounds since Dart's default error message is not useful for negative indexes